### PR TITLE
Add TODO app with Gantt chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
 # codex_sample
-TODO and Schedule
+
+This repository contains a minimal TODO application that can store tasks with deadlines and generate a simple Gantt chart. A small Flask web interface is also included.
+
+## Requirements
+
+- Python 3
+- matplotlib (`pip install matplotlib`)
+- Flask (`pip install flask`)
+
+## CLI Usage
+
+Add tasks specifying a start date and a deadline:
+
+```bash
+python todo.py add "Write report" 2023-12-01 2023-12-05
+```
+
+Tasks are saved in `tasks.json` by default. You can specify a custom file with `--file`.
+
+Generate a Gantt chart showing all tasks:
+
+```bash
+python todo.py gantt chart.png
+```
+
+This will create `chart.png` containing a horizontal bar chart of your tasks.
+
+## Web Usage
+
+Run the Flask app and open `http://localhost:5000` in your browser:
+
+```bash
+python webapp.py
+```
+
+You can add tasks through the form and view the Gantt chart via the link on the page.

--- a/tasks.json
+++ b/tasks.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "Sample Task",
+    "start": "2023-11-01",
+    "deadline": "2023-11-05"
+  }
+]

--- a/todo.py
+++ b/todo.py
@@ -1,0 +1,81 @@
+import argparse
+import json
+from datetime import datetime
+from pathlib import Path
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+
+TASKS_FILE = Path('tasks.json')
+
+
+def load_tasks(file_path: Path = TASKS_FILE):
+    if file_path.exists():
+        with open(file_path, 'r') as f:
+            return json.load(f)
+    return []
+
+
+def save_tasks(tasks, file_path: Path = TASKS_FILE):
+    with open(file_path, 'w') as f:
+        json.dump(tasks, f, indent=2)
+
+
+def add_task(args):
+    tasks = load_tasks(Path(args.file))
+    tasks.append({
+        'name': args.name,
+        'start': args.start,
+        'deadline': args.deadline,
+    })
+    save_tasks(tasks, Path(args.file))
+    print(f"Added task '{args.name}'")
+
+
+def plot_gantt(args):
+    tasks = load_tasks(Path(args.file))
+    if not tasks:
+        print('No tasks found.')
+        return
+
+    # Prepare data
+    starts = [datetime.strptime(t['start'], '%Y-%m-%d') for t in tasks]
+    ends = [datetime.strptime(t['deadline'], '%Y-%m-%d') for t in tasks]
+    durations = [(e - s).days for s, e in zip(starts, ends)]
+    names = [t['name'] for t in tasks]
+
+    fig, ax = plt.subplots(figsize=(8, 0.5 * len(tasks)))
+
+    ax.barh(range(len(tasks)), durations, left=mdates.date2num(starts), height=0.4)
+    ax.set_yticks(range(len(tasks)))
+    ax.set_yticklabels(names)
+    ax.xaxis_date()
+    ax.set_xlabel('Date')
+    plt.tight_layout()
+    plt.savefig(args.output)
+    print(f'Gantt chart saved to {args.output}')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Simple TODO app with Gantt chart')
+    parser.add_argument('--file', default=str(TASKS_FILE), help='Tasks JSON file')
+    subparsers = parser.add_subparsers(dest='command')
+
+    add_p = subparsers.add_parser('add', help='Add a new task')
+    add_p.add_argument('name', help='Task name')
+    add_p.add_argument('start', help='Start date YYYY-MM-DD')
+    add_p.add_argument('deadline', help='Deadline date YYYY-MM-DD')
+    add_p.set_defaults(func=add_task)
+
+    gantt_p = subparsers.add_parser('gantt', help='Generate Gantt chart')
+    gantt_p.add_argument('output', help='Output image file')
+    gantt_p.set_defaults(func=plot_gantt)
+
+    args = parser.parse_args()
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/webapp.py
+++ b/webapp.py
@@ -1,0 +1,77 @@
+from flask import Flask, render_template_string, request, redirect, send_file
+import json
+from datetime import datetime
+from pathlib import Path
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import io
+
+TASKS_FILE = Path('tasks.json')
+
+app = Flask(__name__)
+
+def load_tasks(file_path: Path = TASKS_FILE):
+    if file_path.exists():
+        with open(file_path, 'r') as f:
+            return json.load(f)
+    return []
+
+def save_tasks(tasks, file_path: Path = TASKS_FILE):
+    with open(file_path, 'w') as f:
+        json.dump(tasks, f, indent=2)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        name = request.form['name']
+        start = request.form['start']
+        deadline = request.form['deadline']
+        tasks = load_tasks()
+        tasks.append({'name': name, 'start': start, 'deadline': deadline})
+        save_tasks(tasks)
+        return redirect('/')
+    tasks = load_tasks()
+    html = '''
+    <h1>TODO List</h1>
+    <form method="post">
+      Task: <input name="name" required>
+      Start: <input name="start" type="date" required>
+      Deadline: <input name="deadline" type="date" required>
+      <input type="submit" value="Add">
+    </form>
+    <ul>
+    {% for t in tasks %}
+      <li>{{ t.name }} ({{ t.start }} - {{ t.deadline }})</li>
+    {% endfor %}
+    </ul>
+    <p><a href="/gantt">View Gantt chart</a></p>
+    '''
+    return render_template_string(html, tasks=tasks)
+
+@app.route('/gantt')
+def gantt():
+    tasks = load_tasks()
+    if not tasks:
+        return 'No tasks found.'
+
+    starts = [datetime.strptime(t['start'], '%Y-%m-%d') for t in tasks]
+    ends = [datetime.strptime(t['deadline'], '%Y-%m-%d') for t in tasks]
+    durations = [(e - s).days for s, e in zip(starts, ends)]
+    names = [t['name'] for t in tasks]
+
+    fig, ax = plt.subplots(figsize=(8, 0.5 * len(tasks)))
+    ax.barh(range(len(tasks)), durations, left=mdates.date2num(starts), height=0.4)
+    ax.set_yticks(range(len(tasks)))
+    ax.set_yticklabels(names)
+    ax.xaxis_date()
+    ax.set_xlabel('Date')
+    plt.tight_layout()
+
+    buf = io.BytesIO()
+    plt.savefig(buf, format='png')
+    plt.close(fig)
+    buf.seek(0)
+    return send_file(buf, mimetype='image/png')
+
+if __name__ == '__main__':
+    app.run()


### PR DESCRIPTION
## Summary
- create a simple CLI todo app in `todo.py`
- document how to add tasks and generate a Gantt chart in README
- add a sample `tasks.json`
- **add Flask web interface for tasks and chart**

## Testing
- `python3 -m py_compile todo.py webapp.py`
